### PR TITLE
Externalized strings + german translation

### DIFF
--- a/app/src/main/kotlin/net/syncthing/lite/activities/FolderBrowserActivity.kt
+++ b/app/src/main/kotlin/net/syncthing/lite/activities/FolderBrowserActivity.kt
@@ -127,7 +127,7 @@ class FolderBrowserActivity : SyncthingActivity() {
                     object : AsyncTask<Void?, Void?, Void?>() {
                         override fun onPreExecute() {
                             // TODO: show ProgressBar in ListView instead of dialog
-                            showLoadingDialog("open directory: " +
+                            showLoadingDialog(getString(R.string.open_directory) +
                                     if (indexBrowser!!.isRoot) folderBrowser()?.getFolderInfo(indexBrowser!!.folder)?.label
                                     else indexBrowser!!.currentPathFileName)
                         }
@@ -176,8 +176,8 @@ class FolderBrowserActivity : SyncthingActivity() {
     }
 
     override fun onIndexUpdateProgress(folder: FolderInfo, percentage: Int) {
-        binding.mainIndexProgressBarLabel.text = ("index update, folder "
-                + folder.label + " " + percentage + "% synchronized")
+        binding.mainIndexProgressBarLabel.text = (getString(R.string.index_update_folder)
+                + folder.label + " " + percentage + getString(R.string.index_update_percent_synchronized))
         updateFolderListView()
     }
 

--- a/app/src/main/kotlin/net/syncthing/lite/activities/MainActivity.kt
+++ b/app/src/main/kotlin/net/syncthing/lite/activities/MainActivity.kt
@@ -100,7 +100,7 @@ class MainActivity : SyncthingActivity() {
 
     override fun onIndexUpdateProgress(folder: FolderInfo, percentage: Int) {
         binding.mainIndexProgressBar.visibility = View.VISIBLE
-        binding.mainIndexProgressBarLabel.text = (getString(R.string.index_update_folder)
+        binding.mainIndexProgressBarLabel.text = (getString(R.string.index_update_folder) + " "
                 + folder.label + " " + percentage + getString(R.string.index_update_percent_synchronized))
     }
 

--- a/app/src/main/kotlin/net/syncthing/lite/activities/MainActivity.kt
+++ b/app/src/main/kotlin/net/syncthing/lite/activities/MainActivity.kt
@@ -74,8 +74,8 @@ class MainActivity : SyncthingActivity() {
             R.id.devices -> setContentFragment(DevicesFragment())
             R.id.update_index -> UpdateIndexTask(this, syncthingClient()).updateIndex()
             R.id.clear_index -> AlertDialog.Builder(this)
-                    .setTitle("Clear local cache and index?")
-                    .setMessage("Clear all local cache data and index data?")
+                    .setTitle(getString(R.string.clear_cache_and_index_title))
+                    .setMessage(getString(R.string.clear_cache_and_index_body))
                     .setIcon(android.R.drawable.ic_dialog_alert)
                     .setPositiveButton(android.R.string.yes) { _, _ -> cleanCacheAndIndex() }
                     .setNegativeButton(android.R.string.no, null)
@@ -100,8 +100,8 @@ class MainActivity : SyncthingActivity() {
 
     override fun onIndexUpdateProgress(folder: FolderInfo, percentage: Int) {
         binding.mainIndexProgressBar.visibility = View.VISIBLE
-        binding.mainIndexProgressBarLabel.text = ("Index update, folder "
-                + folder.label + " " + percentage + "% synchronized")
+        binding.mainIndexProgressBarLabel.text = (getString(R.string.index_update_folder)
+                + folder.label + " " + percentage + getString(R.string.index_update_percent_synchronized))
     }
 
     override fun onIndexUpdateComplete() {

--- a/app/src/main/kotlin/net/syncthing/lite/activities/SyncthingActivity.kt
+++ b/app/src/main/kotlin/net/syncthing/lite/activities/SyncthingActivity.kt
@@ -38,7 +38,7 @@ abstract class SyncthingActivity : AppCompatActivity() {
         if (libraryHandler == null) {
             val binding = DataBindingUtil.inflate<DialogLoadingBinding>(
                     LayoutInflater.from(this), R.layout.dialog_loading, null, false)
-            binding.loadingText.text = "loading config, starting syncthing client"
+            binding.loadingText.text = getString(R.string.loading_config_starting_syncthing_client)
             loadingDialog = AlertDialog.Builder(this)
                     .setCancelable(false)
                     .setView(binding.root)

--- a/app/src/main/kotlin/net/syncthing/lite/adapters/FolderContentsAdapter.kt
+++ b/app/src/main/kotlin/net/syncthing/lite/adapters/FolderContentsAdapter.kt
@@ -32,7 +32,7 @@ class FolderContentsAdapter(context: Context) :
             binding.fileIcon.setImageResource(R.drawable.ic_image_black_24dp)
             binding.fileSize.visibility = View.VISIBLE
             binding.fileSize.text = (FileUtils.byteCountToDisplaySize(fileInfo.size!!)
-                    + " - last modified "
+                    + context.getString(R.string.last_modified)
                     + DateUtils.getRelativeDateTimeString(context, fileInfo.lastModified.time, DateUtils.MINUTE_IN_MILLIS, DateUtils.WEEK_IN_MILLIS, 0))
         }
         return binding.root

--- a/app/src/main/kotlin/net/syncthing/lite/adapters/FoldersListAdapter.kt
+++ b/app/src/main/kotlin/net/syncthing/lite/adapters/FoldersListAdapter.kt
@@ -28,8 +28,8 @@ class FoldersListAdapter(context: Context?, list: List<Pair<FolderInfo, FolderSt
         binding.folderName.text = "${folderInfo.label} (${folderInfo.folder})"
         binding.folderLastmodInfo.text =
                 if (folderStats.lastUpdate == null)
-                    "last modified: unknown"
-                else "last modified: " +
+                    context.getString(R.string.last_modified_unknown)
+                else context.getString(R.string.last_modified_known) +
                         DateUtils.getRelativeDateTimeString(context, folderStats.lastUpdate.time, DateUtils.MINUTE_IN_MILLIS, DateUtils.WEEK_IN_MILLIS, 0)
         binding.folderContentInfo.text = "${folderStats.describeSize()}, ${folderStats.fileCount} files, ${folderStats.dirCount} dirs"
         return binding.root

--- a/app/src/main/kotlin/net/syncthing/lite/adapters/FoldersListAdapter.kt
+++ b/app/src/main/kotlin/net/syncthing/lite/adapters/FoldersListAdapter.kt
@@ -29,7 +29,7 @@ class FoldersListAdapter(context: Context?, list: List<Pair<FolderInfo, FolderSt
         binding.folderLastmodInfo.text =
                 if (folderStats.lastUpdate == null)
                     context.getString(R.string.last_modified_unknown)
-                else context.getString(R.string.last_modified_known) +
+                else context.getString(R.string.last_modified_known) + " " +
                         DateUtils.getRelativeDateTimeString(context, folderStats.lastUpdate.time, DateUtils.MINUTE_IN_MILLIS, DateUtils.WEEK_IN_MILLIS, 0)
         binding.folderContentInfo.text = "${folderStats.describeSize()}, ${folderStats.fileCount} files, ${folderStats.dirCount} dirs"
         return binding.root

--- a/app/src/main/kotlin/net/syncthing/lite/fragments/DevicesFragment.kt
+++ b/app/src/main/kotlin/net/syncthing/lite/fragments/DevicesFragment.kt
@@ -54,8 +54,8 @@ class DevicesFragment : SyncthingFragment() {
         binding.list.setOnItemLongClickListener { _, _, position, _ ->
             val deviceId = (binding.list.getItemAtPosition(position) as DeviceStats).deviceId
             AlertDialog.Builder(context)
-                    .setTitle(getString(R.string.remove_device_title) + deviceId.substring(0, 7) + "?")
-                    .setMessage(getString(R.string.remove_device_body_1) + deviceId.substring(0, 7) + getString(R.string.remove_device_body_2))
+                    .setTitle(getString(R.string.remove_device_title) + " " + deviceId.substring(0, 7) + "?")
+                    .setMessage(getString(R.string.remove_device_body_1) + " " + deviceId.substring(0, 7) + " " + getString(R.string.remove_device_body_2))
                     .setPositiveButton(android.R.string.yes) { _, _ ->
                         getSyncthingActivity().configuration().edit().removePeer(deviceId).persistLater() }
                     .setNegativeButton(android.R.string.no, null)

--- a/app/src/main/kotlin/net/syncthing/lite/fragments/DevicesFragment.kt
+++ b/app/src/main/kotlin/net/syncthing/lite/fragments/DevicesFragment.kt
@@ -54,8 +54,8 @@ class DevicesFragment : SyncthingFragment() {
         binding.list.setOnItemLongClickListener { _, _, position, _ ->
             val deviceId = (binding.list.getItemAtPosition(position) as DeviceStats).deviceId
             AlertDialog.Builder(context)
-                    .setTitle("Remove device " + deviceId.substring(0, 7) + "?")
-                    .setMessage("Remove device " + deviceId.substring(0, 7) + " from list of known devices?")
+                    .setTitle(getString(R.string.remove_device_title) + deviceId.substring(0, 7) + "?")
+                    .setMessage(getString(R.string.remove_device_body_1) + deviceId.substring(0, 7) + getString(R.string.remove_device_body_2))
                     .setPositiveButton(android.R.string.yes) { _, _ ->
                         getSyncthingActivity().configuration().edit().removePeer(deviceId).persistLater() }
                     .setNegativeButton(android.R.string.no, null)
@@ -93,11 +93,11 @@ class DevicesFragment : SyncthingFragment() {
         val modified = getSyncthingActivity().configuration().edit().addPeers(DeviceInfo(deviceId, null))
         if (modified) {
             getSyncthingActivity().configuration().edit().persistLater()
-            Toast.makeText(context, "successfully imported device: " + deviceId, Toast.LENGTH_SHORT).show()
+            Toast.makeText(context, getString(R.string.device_import_success) + deviceId, Toast.LENGTH_SHORT).show()
             updateDeviceList()//TODO remove this if event triggered (and handler trigger update)
             UpdateIndexTask(context!!, getSyncthingActivity().syncthingClient()).updateIndex()
         } else {
-            Toast.makeText(context, "device already present: " + deviceId, Toast.LENGTH_SHORT).show()
+            Toast.makeText(context, getString(R.string.device_already_known) + deviceId, Toast.LENGTH_SHORT).show()
         }
     }
 

--- a/app/src/main/kotlin/net/syncthing/lite/fragments/DevicesFragment.kt
+++ b/app/src/main/kotlin/net/syncthing/lite/fragments/DevicesFragment.kt
@@ -93,11 +93,11 @@ class DevicesFragment : SyncthingFragment() {
         val modified = getSyncthingActivity().configuration().edit().addPeers(DeviceInfo(deviceId, null))
         if (modified) {
             getSyncthingActivity().configuration().edit().persistLater()
-            Toast.makeText(context, getString(R.string.device_import_success) + deviceId, Toast.LENGTH_SHORT).show()
+            Toast.makeText(context, getString(R.string.device_import_success) + " " + deviceId, Toast.LENGTH_SHORT).show()
             updateDeviceList()//TODO remove this if event triggered (and handler trigger update)
             UpdateIndexTask(context!!, getSyncthingActivity().syncthingClient()).updateIndex()
         } else {
-            Toast.makeText(context, getString(R.string.device_already_known) + deviceId, Toast.LENGTH_SHORT).show()
+            Toast.makeText(context, getString(R.string.device_already_known) + " " + deviceId, Toast.LENGTH_SHORT).show()
         }
     }
 

--- a/app/src/main/kotlin/net/syncthing/lite/library/DownloadFileTask.kt
+++ b/app/src/main/kotlin/net/syncthing/lite/library/DownloadFileTask.kt
@@ -31,8 +31,7 @@ class DownloadFileTask(private val mContext: Context, private val mSyncthingClie
 
     fun downloadFile() {
         showDialog()
-        // Don't pass file info directly.
-        mSyncthingClient.pullFile(mFileInfo.folder, mFileInfo.path, { observer ->
+        mSyncthingClient.pullFile(mFileInfo, { observer ->
             onProgress(observer)
             try {
                 while (!observer.isCompleted) {

--- a/app/src/main/kotlin/net/syncthing/lite/library/DownloadFileTask.kt
+++ b/app/src/main/kotlin/net/syncthing/lite/library/DownloadFileTask.kt
@@ -31,7 +31,8 @@ class DownloadFileTask(private val mContext: Context, private val mSyncthingClie
 
     fun downloadFile() {
         showDialog()
-        mSyncthingClient.pullFile(mFileInfo, { observer ->
+        // Don't pass file info directly.
+        mSyncthingClient.pullFile(mFileInfo.folder, mFileInfo.path, { observer ->
             onProgress(observer)
             try {
                 while (!observer.isCompleted) {

--- a/app/src/main/res/menu/drawer_view.xml
+++ b/app/src/main/res/menu/drawer_view.xml
@@ -4,14 +4,14 @@
 
         <item
             android:id="@+id/folders"
+            android:checked="true"
             android:icon="@drawable/ic_folder_gray_24dp"
-            android:title="Folders"
-            android:checked="true"/>
+            android:title="@string/folders_label" />
 
         <item
             android:id="@+id/devices"
             android:icon="@drawable/ic_laptop_gray_24dp"
-            android:title="Devices" />
+            android:title="@string/devices_label" />
 
         <item
             android:id="@+id/update_index"

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -33,4 +33,6 @@
     <string name="remove_device_body_2">von den bekannten Geräten entfernen?</string>
     <string name="device_import_success">Gerät erfolgreich importiert:</string>
     <string name="device_already_known">Gerät ist bereits bekannt:</string>
+    <string name="folders_label">Ordner</string>
+    <string name="devices_label">Geräte</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -3,7 +3,7 @@
     <string name="index_update_progress_message">Index wird aktualisiert...</string>
     <string name="folder_list_empty_message">Keine Ordner verfügbar</string>
     <string name="clear_local_cache_index_label">Lokalen Index und Cache löschen</string>
-    <string name="update_remote_index_label">Entfernten Index aktualisieren</string>
+    <string name="update_remote_index_label">Index aktualisieren</string>
     <string name="devices_list_view_empty_message">Keine Geräte verfügbar</string>
     <string name="toast_write_storage_permission_required">Schreibrechte werden für diese Funktion benötigt</string>
     <string name="scan_qr_code">QR code scannen</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Syncthing Lite</string>
+    <string name="index_update_progress_message">Index wird aktualisiert...</string>
+    <string name="folder_list_empty_message">Keine Ordner verfügbar</string>
+    <string name="clear_local_cache_index_label">Lokalen Index und Cache entleeren</string>
+    <string name="update_remote_index_label">Entfernten Index aktualisieren</string>
+    <string name="devices_list_view_empty_message">Keine Geräte verfügbar</string>
+    <string name="toast_write_storage_permission_required">Schreibrechte werden für diese Funktion benötigt</string>
+    <string name="scan_qr_code">QR code scannen</string>
+    <string name="enter_device_id">Geräte ID eingeben</string>
+    <string name="invalid_device_id">Ungültige Geräte ID</string>
+    <string name="device_id_dialog_title">Geräte ID eingeben</string>
+    <string name="toast_index_update_successful">Index erfolgreich aktualisiert</string>
+    <string name="toast_index_update_failed">Index update für %1$d Geräte fehlgeschlagen</string>
+    <string name="dialog_downloading_file">Datei %1$s wird heruntergeladen</string>
+    <string name="toast_file_download_failed">Datei konnte nicht heruntergeladen werden</string>
+    <string name="toast_open_file_failed">Keine kompatible app gefunden</string>
+    <string name="toast_file_upload_failed">Hochladen gescheitert</string>
+    <string name="toast_upload_complete">Hochladen erfolgreich</string>
+    <string name="dialog_uploading_file">Datei %1$s wird hochgeladen</string>
+    <string name="directory_empty">Ordner ist leer</string>
+    <string name="clear_cache_and_index_title">Lokalen Cache und Index leeren?</string>
+    <string name="clear_cache_and_index_body">Gesamten lokalen Cache und Index löschen?</string>
+    <string name="index_update_folder">Index aktualisierung, Ordner</string>
+    <string name="index_update_percent_synchronized">% synchronisiert</string>
+    <string name="open_directory">Ordner öffnen:</string>
+    <string name="loading_config_starting_syncthing_client">Konfiguartion wird geladen, Syncthing wird gestartet</string>
+    <string name="last_modified">- zuletzt modifiziert</string>
+    <string name="last_modified_unknown">zuletzt modifiziert: unbekannt</string>
+    <string name="last_modified_known">zuletzt modifiziert:</string>
+    <string name="remove_device_title">Gerät entfernen?</string>
+    <string name="remove_device_body_1">Gerät</string>
+</resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -28,7 +28,7 @@
     <string name="last_modified">- zuletzt modifiziert</string>
     <string name="last_modified_unknown">zuletzt modifiziert: unbekannt</string>
     <string name="last_modified_known">zuletzt modifiziert:</string>
-    <string name="remove_device_title">Gerät entfernen?</string>
+    <string name="remove_device_title">Gerät entfernen:</string>
     <string name="remove_device_body_1">Gerät</string>
     <string name="remove_device_body_2">von den bekannten Geräten entfernen?</string>
     <string name="device_import_success">Gerät erfolgreich importiert:</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -19,7 +19,7 @@
     <string name="toast_upload_complete">Hochladen erfolgreich</string>
     <string name="dialog_uploading_file">Datei %1$s wird hochgeladen</string>
     <string name="directory_empty">Ordner ist leer</string>
-    <string name="clear_cache_and_index_title">Lokalen Cache und Index leeren?</string>
+    <string name="clear_cache_and_index_title">Lokalen Cache und Index löschen?</string>
     <string name="clear_cache_and_index_body">Gesamten lokalen Cache und Index löschen?</string>
     <string name="index_update_folder">Index aktualisierung, Ordner</string>
     <string name="index_update_percent_synchronized">% synchronisiert</string>
@@ -30,7 +30,7 @@
     <string name="last_modified_known">zuletzt modifiziert:</string>
     <string name="remove_device_title">Gerät entfernen?</string>
     <string name="remove_device_body_1">Gerät</string>
-    <string name="remove_device_body_2">von von den bekannten Geräten entfernen?</string>
+    <string name="remove_device_body_2">von den bekannten Geräten entfernen?</string>
     <string name="device_import_success">Gerät erfolgreich importiert:</string>
     <string name="device_already_known">Gerät ist bereits bekannt:</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Syncthing Lite</string>
     <string name="index_update_progress_message">Index wird aktualisiert...</string>
     <string name="folder_list_empty_message">Keine Ordner verfügbar</string>
-    <string name="clear_local_cache_index_label">Lokalen Index und Cache entleeren</string>
+    <string name="clear_local_cache_index_label">Lokalen Index und Cache löschen</string>
     <string name="update_remote_index_label">Entfernten Index aktualisieren</string>
     <string name="devices_list_view_empty_message">Keine Geräte verfügbar</string>
     <string name="toast_write_storage_permission_required">Schreibrechte werden für diese Funktion benötigt</string>
@@ -31,4 +30,7 @@
     <string name="last_modified_known">zuletzt modifiziert:</string>
     <string name="remove_device_title">Gerät entfernen?</string>
     <string name="remove_device_body_1">Gerät</string>
+    <string name="remove_device_body_2">von von den bekannten Geräten entfernen?</string>
+    <string name="device_import_success">Gerät erfolgreich importiert:</string>
+    <string name="device_already_known">Gerät ist bereits bekannt:</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,15 +24,15 @@
     <string name="index_update_folder">Index update, folder</string>
     <string name="index_update_percent_synchronized">% synchronized</string>
     <string name="open_directory">open directory:</string>
-    <string name="loading_config_starting_syncthing_client">loading config, starting syncthing client</string>
+    <string name="loading_config_starting_syncthing_client">Loading config, starting syncthing client</string>
     <string name="last_modified">- last modified</string>
     <string name="last_modified_unknown">last modified: unknown</string>
     <string name="last_modified_known">last modified:</string>
     <string name="remove_device_title">Remove device?</string>
     <string name="remove_device_body_1">Remove device</string>
     <string name="remove_device_body_2">from list of known devices?</string>
-    <string name="device_import_success">successfully imported device:</string>
-    <string name="device_already_known">device already present:</string>
+    <string name="device_import_success">Successfully imported device:</string>
+    <string name="device_already_known">Device already present:</string>
     <string name="folders_label">Folders</string>
     <string name="devices_label">Devices</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,4 +28,9 @@
     <string name="last_modified">- last modified</string>
     <string name="last_modified_unknown">last modified: unknown</string>
     <string name="last_modified_known">last modified:</string>
+    <string name="remove_device_title">Remove device</string>
+    <string name="remove_device_body_1">Remove device</string>
+    <string name="remove_device_body_2">from list of known devices?</string>
+    <string name="device_import_success">successfully imported device:</string>
+    <string name="device_already_known">device already present:</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,4 +24,8 @@
     <string name="index_update_folder">Index update, folder</string>
     <string name="index_update_percent_synchronized">% synchronized</string>
     <string name="open_directory">open directory:</string>
+    <string name="loading_config_starting_syncthing_client">loading config, starting syncthing client</string>
+    <string name="last_modified">- last modified</string>
+    <string name="last_modified_unknown">last modified: unknown</string>
+    <string name="last_modified_known">last modified:</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,4 +19,8 @@
     <string name="toast_upload_complete">File upload complete</string>
     <string name="dialog_uploading_file">Uploading file %1$s</string>
     <string name="directory_empty">Directory is empty</string>
+    <string name="clear_cache_and_index_title">Clear local cache and index?</string>
+    <string name="clear_cache_and_index_body">Clear all local cache data and index data?</string>
+    <string name="index_update_folder">Index update, folder</string>
+    <string name="index_update_percent_synchronized">% synchronized</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,4 +23,5 @@
     <string name="clear_cache_and_index_body">Clear all local cache data and index data?</string>
     <string name="index_update_folder">Index update, folder</string>
     <string name="index_update_percent_synchronized">% synchronized</string>
+    <string name="open_directory">open directory:</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,7 +28,7 @@
     <string name="last_modified">- last modified</string>
     <string name="last_modified_unknown">last modified: unknown</string>
     <string name="last_modified_known">last modified:</string>
-    <string name="remove_device_title">Remove device</string>
+    <string name="remove_device_title">Remove device?</string>
     <string name="remove_device_body_1">Remove device</string>
     <string name="remove_device_body_2">from list of known devices?</string>
     <string name="device_import_success">successfully imported device:</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,7 +28,7 @@
     <string name="last_modified">- last modified</string>
     <string name="last_modified_unknown">last modified: unknown</string>
     <string name="last_modified_known">last modified:</string>
-    <string name="remove_device_title">Remove device?</string>
+    <string name="remove_device_title">Remove device:</string>
     <string name="remove_device_body_1">Remove device</string>
     <string name="remove_device_body_2">from list of known devices?</string>
     <string name="device_import_success">Successfully imported device:</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">Syncthing Lite</string>
+    <string name="app_name" translatable="false">Syncthing Lite</string>
     <string name="index_update_progress_message">Index update…</string>
     <string name="folder_list_empty_message">No folder available</string>
     <string name="clear_local_cache_index_label">Clear local cache/index</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,4 +33,6 @@
     <string name="remove_device_body_2">from list of known devices?</string>
     <string name="device_import_success">successfully imported device:</string>
     <string name="device_already_known">device already present:</string>
+    <string name="folders_label">Folders</string>
+    <string name="devices_label">Devices</string>
 </resources>


### PR DESCRIPTION
I externalized a lot of strings found in the java/kotlin code. There are still some things that need externalization. In layout for example. I don't know if it works, because android studio can't compile the apk. I may externalize the strings in layout if I manage to compile it. 
Heres the error I got:
```
C:\<redacted>\syncthing-lite\app\src\main\kotlin\net\syncthing\lite\library\DownloadFileTask.kt
Error:(34, 35) Type mismatch: inferred type is FileInfo but String was expected
Error:(34, 46) Type mismatch: inferred type is (???) -> Unit but String was expected
Error:(34, 48) Cannot infer a type for this parameter. Please specify it explicitly.
Error:(58, 10) No value passed for parameter 'listener'
Error:Execution failed for task ':app:compileDebugKotlin'.
> Compilation error. See log for more details
```
Note: I didn't modify this file in any way, nor do I have any experience with compiling apks. 